### PR TITLE
Implementation hotfixes 2

### DIFF
--- a/components/cms-token-auth/cms-token-auth-config.js
+++ b/components/cms-token-auth/cms-token-auth-config.js
@@ -24,8 +24,6 @@ angular.module('cmsComponents.auth.config', [
       var authSuccessHandlers = [];
       // HTTP codes this module should handle
       var handleHttpCodes = [401, 403];
-      // path to login page
-      var loginPagePath = '';
       // url for logo to display on login page
       var logoUrl = '';
       // list of regular expressions to match request urls, only matched urls will
@@ -124,15 +122,6 @@ angular.module('cmsComponents.auth.config', [
         return this;
       };
 
-      this.setLoginPagePath = function (value) {
-        if (_.isString(value)) {
-          loginPagePath = value;
-        } else {
-          throw new TypeError('TokenAuthConfig.loginPagePath must be a string!');
-        }
-        return this;
-      };
-
       this.setLogoUrl = function (value) {
         if (_.isString(value)) {
           logoUrl = value;
@@ -183,7 +172,6 @@ angular.module('cmsComponents.auth.config', [
           getApiEndpointRefresh: _.constant(apiHost + apiEndpointRefresh),
           getApiEndpointCurrentUser: _.constant(apiHost + apiEndpointCurrentUser),
           getApiEndpointVerify: _.constant(apiHost + apiEndpointVerify),
-          getLoginPagePath: _.constant(loginPagePath),
           getLogoUrl: _.constant(logoUrl),
           getTokenKey: _.constant(tokenKey),
           callAuthFailureHandlers: function (args) {

--- a/components/cms-token-auth/cms-token-auth-service/cms-token-auth-service.js
+++ b/components/cms-token-auth/cms-token-auth-service/cms-token-auth-service.js
@@ -72,9 +72,9 @@ angular.module('cmsComponents.auth.service', [
         )
           .then(function () {
             verifiedAtLeastOnce = true;
+            TokenAuthService.requestBufferRetry();
             return CurrentUser.$get()
               .then(function (user) {
-                TokenAuthService.requestBufferRetry();
                 TokenAuthConfig.callAuthSuccessHandlers(user);
               });
           })
@@ -141,9 +141,9 @@ angular.module('cmsComponents.auth.service', [
           .then(function (tokenResponse) {
             localStorageService.set(TokenAuthConfig.getTokenKey(), tokenResponse.data.token);
             verifiedAtLeastOnce = true;
+            TokenAuthService.requestBufferRetry();
             return CurrentUser.$get()
               .then(function (user) {
-                TokenAuthService.requestBufferRetry();
                 TokenAuthConfig.callAuthSuccessHandlers(user);
               });
           })

--- a/components/cms-token-auth/cms-token-auth-service/cms-token-auth-service.spec.js
+++ b/components/cms-token-auth/cms-token-auth-service/cms-token-auth-service.spec.js
@@ -151,6 +151,16 @@ describe('Service: TokenAuthService', function () {
         expect(TokenAuthService.requestBufferRetry.calledOnce).to.be.true;
       });
 
+      it('should retry request buffer independent of current user request', function () {
+        TokenAuthService.requestBufferRetry = sandbox.stub();
+
+        CurrentUser.$get = sandbox.stub().returns($q.reject({status: 404}));
+        TokenAuthService.tokenVerify();
+        $httpBackend.flush();
+
+        expect(TokenAuthService.requestBufferRetry.calledOnce).to.be.true;
+      });
+
       it('should call auth success handlers with user', function () {
         TokenAuthConfig.callAuthSuccessHandlers = sandbox.stub().withArgs(fakeUser);
 
@@ -235,6 +245,18 @@ describe('Service: TokenAuthService', function () {
       TokenAuthService.requestBufferRetry = sandbox.stub();
       localStorageService.get = sandbox.stub().returns(testToken);
       CurrentUser.$get = sandbox.stub().returns($q.resolve());
+      requestRefresh().respond(200, {});
+
+      TokenAuthService.tokenRefresh();
+      $httpBackend.flush();
+
+      expect(TokenAuthService.requestBufferRetry.calledOnce).to.be.true;
+    });
+
+    it('should retry request buffer even if user request not finished on success', function () {
+      TokenAuthService.requestBufferRetry = sandbox.stub();
+      localStorageService.get = sandbox.stub().returns(testToken);
+      CurrentUser.$get = sandbox.stub().returns($q.reject({status: 404}));
       requestRefresh().respond(200, {});
 
       TokenAuthService.tokenRefresh();

--- a/dist/cms-components.js
+++ b/dist/cms-components.js
@@ -1665,8 +1665,6 @@
 	      var authSuccessHandlers = [];
 	      // HTTP codes this module should handle
 	      var handleHttpCodes = [401, 403];
-	      // path to login page
-	      var loginPagePath = '';
 	      // url for logo to display on login page
 	      var logoUrl = '';
 	      // list of regular expressions to match request urls, only matched urls will
@@ -1765,15 +1763,6 @@
 	        return this;
 	      };
 
-	      this.setLoginPagePath = function (value) {
-	        if (_.isString(value)) {
-	          loginPagePath = value;
-	        } else {
-	          throw new TypeError('TokenAuthConfig.loginPagePath must be a string!');
-	        }
-	        return this;
-	      };
-
 	      this.setLogoUrl = function (value) {
 	        if (_.isString(value)) {
 	          logoUrl = value;
@@ -1824,7 +1813,6 @@
 	          getApiEndpointRefresh: _.constant(apiHost + apiEndpointRefresh),
 	          getApiEndpointCurrentUser: _.constant(apiHost + apiEndpointCurrentUser),
 	          getApiEndpointVerify: _.constant(apiHost + apiEndpointVerify),
-	          getLoginPagePath: _.constant(loginPagePath),
 	          getLogoUrl: _.constant(logoUrl),
 	          getTokenKey: _.constant(tokenKey),
 	          callAuthFailureHandlers: function (args) {
@@ -2188,9 +2176,9 @@
 	        )
 	          .then(function () {
 	            verifiedAtLeastOnce = true;
+	            TokenAuthService.requestBufferRetry();
 	            return CurrentUser.$get()
 	              .then(function (user) {
-	                TokenAuthService.requestBufferRetry();
 	                TokenAuthConfig.callAuthSuccessHandlers(user);
 	              });
 	          })
@@ -2257,9 +2245,9 @@
 	          .then(function (tokenResponse) {
 	            localStorageService.set(TokenAuthConfig.getTokenKey(), tokenResponse.data.token);
 	            verifiedAtLeastOnce = true;
+	            TokenAuthService.requestBufferRetry();
 	            return CurrentUser.$get()
 	              .then(function (user) {
-	                TokenAuthService.requestBufferRetry();
 	                TokenAuthConfig.callAuthSuccessHandlers(user);
 	              });
 	          })


### PR DESCRIPTION
### Fixed

1. Avoid condition where a `CurrentUser.$get` request before a `TokenAuthService.tokenVerify` would lock up the token auth logic.

### Breaking

1. Removed unused `loginPagePath` variable and associated methods from `TokenAuthConfig`.